### PR TITLE
fix: Check if `files` exists in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "dependencies": {
     "@expo/spawn-async": "1.5.0",
+    "@schemastore/package": "0.0.5",
     "commander": "3.0.2",
     "commander-remaining-args": "1.2.0",
     "fs-extra": "8.1.0",

--- a/src/PublishFlat.ts
+++ b/src/PublishFlat.ts
@@ -1,4 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
+import PackageJson from '@schemastore/package';
 import fs from 'fs-extra';
 import logdown from 'logdown';
 import packlist from 'npm-packlist';
@@ -115,12 +116,15 @@ export class PublishFlat {
   }
 
   private async cleanPackageJson(filePath: string, filesInFlattenedDir: FilesInFlattenedDir): Promise<void> {
-    const packageJson = await fs.readJSON(filePath);
-    packageJson.files = packageJson.files.map((fileName: string) => fileName.replace(this.dirToFlattenRegex, ''));
-    packageJson.files = packageJson.files
-      .concat(filesInFlattenedDir.map(({replacedFilename}) => replacedFilename))
-      .filter((fileName: string) => fileName !== this.dirToFlatten)
-      .sort();
+    const packageJson: PackageJson.CoreProperties = await fs.readJSON(filePath);
+
+    if (packageJson.files) {
+      packageJson.files = packageJson.files
+        .map(fileName => fileName.replace(this.dirToFlattenRegex, ''))
+        .concat(filesInFlattenedDir.map(({replacedFilename}) => replacedFilename))
+        .filter(fileName => fileName !== this.dirToFlatten)
+        .sort();
+    }
 
     if (typeof packageJson.bin === 'string') {
       packageJson.bin = packageJson.bin.replace(this.dirToFlattenRegex, '');

--- a/src/PublishFlat.ts
+++ b/src/PublishFlat.ts
@@ -118,7 +118,7 @@ export class PublishFlat {
   private async cleanPackageJson(filePath: string, filesInFlattenedDir: FilesInFlattenedDir): Promise<void> {
     const packageJson: PackageJson = await fs.readJSON(filePath);
 
-    if (packageJson.files) {
+    if (Array.isArray(packageJson.files)) {
       packageJson.files = packageJson.files
         .map(fileName => fileName.replace(this.dirToFlattenRegex, ''))
         .concat(filesInFlattenedDir.map(({replacedFilename}) => replacedFilename))

--- a/src/PublishFlat.ts
+++ b/src/PublishFlat.ts
@@ -1,5 +1,5 @@
 import spawnAsync from '@expo/spawn-async';
-import PackageJson from '@schemastore/package';
+import {CoreProperties as PackageJson} from '@schemastore/package';
 import fs from 'fs-extra';
 import logdown from 'logdown';
 import packlist from 'npm-packlist';
@@ -116,7 +116,7 @@ export class PublishFlat {
   }
 
   private async cleanPackageJson(filePath: string, filesInFlattenedDir: FilesInFlattenedDir): Promise<void> {
-    const packageJson: PackageJson.CoreProperties = await fs.readJSON(filePath);
+    const packageJson: PackageJson = await fs.readJSON(filePath);
 
     if (packageJson.files) {
       packageJson.files = packageJson.files

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,6 +118,11 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@schemastore/package@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.npmjs.org/@schemastore/package/-/package-0.0.5.tgz#67b621d5c833ad2d5a29a1acf868717b7839bb8a"
+  integrity sha512-0XEiMT/Rh8I0SEIO81fo5MN3AHhONFv9SJ1IIJ5OTI3PN/jG032OPlHUMxvrun7yc6YUGtufVg2WPQVK8PaH5Q==
+
 "@semantic-release/changelog@3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-3.0.4.tgz#8fc578b76bca5b23c3000694277c38e0fa835edd"


### PR DESCRIPTION
Taking over from https://github.com/ffflorian/publish-flat/pull/93.
This closes #93.

Thanks to @soulofmischief!